### PR TITLE
 Allow build using default configuration for VS2019

### DIFF
--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -120,8 +120,8 @@ task CheckToolChain {
 	doFirst {
 		if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
 			// ensure that required MS Visual Studio is installed where expected
-			String msg = "Microsoft Visual Studio install not found: ${VISUAL_STUDIO_BASE_DIR}\n" +
-					"Adjust path in Ghidra/GPL/nativeBuildProperties.gradle if needed."
+			String msg = "Microsoft Visual Studio install not found: ${VISUAL_STUDIO_BASE_DIR}\n" + 
+				"Adjust path in Ghidra/GPL/nativeBuildProperties.gradle if needed."
 			if (!VISUAL_STUDIO_FOUND) {
 				throw new GradleException(msg);
 			}	

--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -17,21 +17,30 @@ apply plugin: 'c'
 
 // Unclear if we can rely on the VisualCpp plugin to identify the correct Visual Studio paths
 
-project.ext.VISUAL_STUDIO_BASE_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017"
+project.ext.VISUAL_STUDIO_BASE_2017_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017"
+project.ext.VISUAL_STUDIO_BASE_2019_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019"
 project.ext.WINDOWS_KITS_DIR = "C:\\Program Files (x86)\\Windows Kits\\10"
 
 project.ext.VISUAL_STUDIO_INSTALL_DIR = "/"
 project.ext.VISUAL_STUDIO_VCVARS_CMD = "UNKNOWN"
 project.ext.MSVC_SDK_VERSION = "UNKNOWN"
 project.ext.MSVC_TOOLS_VERSION = "UNKNOWN"
+project.ext.VISUAL_STUDIO_FOUND = false
 
 if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
 
-	project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_DIR + "\\Professional"
+	project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_2017_DIR + "\\Professional"
 	if (!file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
-		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_DIR + "\\Community"
+		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_2017_DIR + "\\Community"
+	}
+	if (!file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
+		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_2019_DIR + "\\Professional"
+	}
+	if (!file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
+		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_2019_DIR + "\\Community"
 	}
 	if (file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
+		project.ext.VISUAL_STUDIO_FOUND = true
 
 		println "Visual Studio Path: ${VISUAL_STUDIO_INSTALL_DIR}"
 
@@ -86,10 +95,10 @@ task CheckToolChain {
 	doFirst {
 		if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
 			// ensure that required MS Visual Studio is installed where expected
-			String msg = "Microsoft Visual Studio install not found: ${VISUAL_STUDIO_BASE_DIR}\n" + 
+			String msg = "Microsoft Visual Studio 2017 install not found: ${VISUAL_STUDIO_BASE_2017_DIR}\n" +
+				"Microsoft Visual Studio 2019 install not found: ${VISUAL_STUDIO_BASE_2019_DIR}\n" +
 				"Adjust path in Ghidra/GPL/nativeBuildProperties.gradle if needed."
-			if (!file(VISUAL_STUDIO_BASE_DIR).exists() || 
-					!file(VISUAL_STUDIO_INSTALL_DIR).exists()) {
+			if (!VISUAL_STUDIO_FOUND) {
 				throw new GradleException(msg);
 			}	
 		}

--- a/GPL/nativeBuildProperties.gradle
+++ b/GPL/nativeBuildProperties.gradle
@@ -17,8 +17,7 @@ apply plugin: 'c'
 
 // Unclear if we can rely on the VisualCpp plugin to identify the correct Visual Studio paths
 
-project.ext.VISUAL_STUDIO_BASE_2017_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017"
-project.ext.VISUAL_STUDIO_BASE_2019_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019"
+project.ext.VISUAL_STUDIO_BASE_DIR = "C:\\Program Files (x86)\\Microsoft Visual Studio"
 project.ext.WINDOWS_KITS_DIR = "C:\\Program Files (x86)\\Windows Kits\\10"
 
 project.ext.VISUAL_STUDIO_INSTALL_DIR = "/"
@@ -27,21 +26,47 @@ project.ext.MSVC_SDK_VERSION = "UNKNOWN"
 project.ext.MSVC_TOOLS_VERSION = "UNKNOWN"
 project.ext.VISUAL_STUDIO_FOUND = false
 
+/*******************************************************************************************
+ * Well known SKU of Visual Studio.
+ ******************************************************************************************/
+def editions = ["Enterprise", "Professional", "Community", "Preview"]
+
+/*******************************************************************************************
+ * Supported version of VS by Ghidra
+ ******************************************************************************************/
+def suportedVsVersionCodes = ["2017", "2019"]
+
+/*******************************************************************************************
+ * Attempt to find location of specific version for VS. Lookup for specific version
+ * This function set VISUAL_STUDIO_FOUND property to true once found the VS location
+ * After that, subsequent calls do nothing.
+ ******************************************************************************************/
+def findVsLocation(vsVersionCode, knownVersionEditions) {
+	if (project.ext.VISUAL_STUDIO_FOUND) {
+		return
+	}
+
+	String base_path = project.ext.VISUAL_STUDIO_BASE_DIR + "\\$vsVersionCode\\"
+	knownVersionEditions.each { edition ->
+		if (project.ext.VISUAL_STUDIO_FOUND) {
+			return
+		}
+
+		String path = base_path + edition
+		if (file(path).exists()) {
+			project.ext.VISUAL_STUDIO_FOUND = true
+			project.ext.VISUAL_STUDIO_INSTALL_DIR = path
+			return
+		}
+	}
+}
+
 if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+	suportedVsVersionCodes.each { vsVersionCode ->
+		findVsLocation(vsVersionCode, editions)
+	}
 
-	project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_2017_DIR + "\\Professional"
-	if (!file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
-		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_2017_DIR + "\\Community"
-	}
-	if (!file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
-		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_2019_DIR + "\\Professional"
-	}
-	if (!file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
-		project.ext.VISUAL_STUDIO_INSTALL_DIR = project.ext.VISUAL_STUDIO_BASE_2019_DIR + "\\Community"
-	}
-	if (file(project.ext.VISUAL_STUDIO_INSTALL_DIR).exists()) {
-		project.ext.VISUAL_STUDIO_FOUND = true
-
+	if (project.ext.VISUAL_STUDIO_FOUND) {
 		println "Visual Studio Path: ${VISUAL_STUDIO_INSTALL_DIR}"
 
 		project.ext.VISUAL_STUDIO_VCVARS_CMD = "\"${VISUAL_STUDIO_INSTALL_DIR}\\VC\\Auxiliary\\Build\\vcvarsall.bat\" x86_amd64"
@@ -95,9 +120,8 @@ task CheckToolChain {
 	doFirst {
 		if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
 			// ensure that required MS Visual Studio is installed where expected
-			String msg = "Microsoft Visual Studio 2017 install not found: ${VISUAL_STUDIO_BASE_2017_DIR}\n" +
-				"Microsoft Visual Studio 2019 install not found: ${VISUAL_STUDIO_BASE_2019_DIR}\n" +
-				"Adjust path in Ghidra/GPL/nativeBuildProperties.gradle if needed."
+			String msg = "Microsoft Visual Studio install not found: ${VISUAL_STUDIO_BASE_DIR}\n" +
+					"Adjust path in Ghidra/GPL/nativeBuildProperties.gradle if needed."
 			if (!VISUAL_STUDIO_FOUND) {
 				throw new GradleException(msg);
 			}	

--- a/Ghidra/Features/PDB/build.gradle
+++ b/Ghidra/Features/PDB/build.gradle
@@ -43,7 +43,7 @@ if ("win64".equals(getCurrentPlatformName())) {
 		def solutionPathWindows = "${projectPathWindows}\\src\\pdb\\pdb.sln"
 		def outputPathWindows = "${projectPathWindows}\\build\\os\\win64\\pdb.exe"
 		def platformToolset = 'v' + MSVC_TOOLS_VERSION.substring(0, 4).replace('.', '');
-
+		
 		doFirst {
 			file("build/os/win64").mkdirs()
 			new File(solutionBatchFilePath).withWriter { out ->

--- a/Ghidra/Features/PDB/build.gradle
+++ b/Ghidra/Features/PDB/build.gradle
@@ -42,12 +42,13 @@ if ("win64".equals(getCurrentPlatformName())) {
 		def projectPathWindows = projectPath.replace("/", File.separator)
 		def solutionPathWindows = "${projectPathWindows}\\src\\pdb\\pdb.sln"
 		def outputPathWindows = "${projectPathWindows}\\build\\os\\win64\\pdb.exe"
-		
+		def platformToolset = 'v' + MSVC_TOOLS_VERSION.substring(0, 4).replace('.', '');
+
 		doFirst {
 			file("build/os/win64").mkdirs()
 			new File(solutionBatchFilePath).withWriter { out ->
 				out.println "call " + VISUAL_STUDIO_VCVARS_CMD
-				out.println "devenv ${solutionPathWindows} /build Release /project pdb"
+				out.println "msbuild ${solutionPathWindows} /p:Configuration=Release /p:PlatformToolset=${platformToolset} /p:WindowsTargetPlatformVersion=${MSVC_SDK_VERSION}"
 			}
 		}
 		

--- a/Ghidra/Features/PDB/src/pdb/pdb.vcxproj
+++ b/Ghidra/Features/PDB/src/pdb/pdb.vcxproj
@@ -13,18 +13,21 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{343E9778-3C04-476E-8F90-A114AA7AA108}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' != '16.0'">8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '16.0'">10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '16.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '16.0'">v141</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/Ghidra/Features/PDB/src/pdb/pdb.vcxproj
+++ b/Ghidra/Features/PDB/src/pdb/pdb.vcxproj
@@ -13,21 +13,18 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{343E9778-3C04-476E-8F90-A114AA7AA108}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' != '16.0'">8.1</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '16.0'">10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' != '16.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' != '16.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
This is not optimal implementation, but at least it allow build
for those who do not have VS2017. If both VS2017 and VS2019 installed
VS2017 would be used.

When build run it detect current VC Toolset using existing MSVC_TOOLS_VERSION variable and Windows SDK version detected by MSVC_SDK_VERSION variable

Closes: https://github.com/NationalSecurityAgency/ghidra/issues/699

